### PR TITLE
Add example Next.js app

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,15 @@ python3 self_improvement_app.py
 ```
 
 Im interaktiven Men\u00fc w\u00e4hlt man zuerst einen Benutzer aus, f\u00fcgt Aufgaben f\u00fcr eine der vier Hauptkategorien (emotional, rational, spirituell, transformational) und deren Unterkategorien (ich, du, wir, alles) hinzu und kann anschlie\u00dfend sein Punktekonto betrachten.
+
+## Next.js Anwendung
+
+Dieses Repository enth\u00e4lt zus\u00e4tzlich das Verzeichnis `next-app` mit einem minimalen Next.js-Projekt. Um es zu nutzen, m\u00fcssen Node.js und npm installiert sein.
+
+```bash
+cd next-app
+npm install   # installiert die ben\u00f6tigten Abh\u00e4ngigkeiten
+npm run dev   # startet die Entwicklungsumgebung
+```
+
+Danach ist die Anwendung \u00fcber `http://localhost:3000` erreichbar und zeigt einen einfachen interaktiven Counter.

--- a/next-app/next-env.d.ts
+++ b/next-app/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.
+

--- a/next-app/next.config.js
+++ b/next-app/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "next-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.6.3",
+    "@types/react": "18.2.15",
+    "@types/react-dom": "18.2.6",
+    "eslint": "8.53.0",
+    "eslint-config-next": "14.2.3",
+    "typescript": "5.1.6"
+  }
+}

--- a/next-app/src/pages/404.tsx
+++ b/next-app/src/pages/404.tsx
@@ -1,0 +1,8 @@
+export default function Custom404() {
+  return (
+    <main style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
+      <h1>404 - Seite nicht gefunden</h1>
+      <p>Die angeforderte Ressource konnte nicht gefunden werden.</p>
+    </main>
+  );
+}

--- a/next-app/src/pages/_app.tsx
+++ b/next-app/src/pages/_app.tsx
@@ -1,0 +1,5 @@
+import type { AppProps } from 'next/app';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/next-app/src/pages/index.tsx
+++ b/next-app/src/pages/index.tsx
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+
+export default function Home() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <main style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
+      <h1>Interactive Counter</h1>
+      <p>Current count: {count}</p>
+      <button onClick={() => setCount(count + 1)}>Increase</button>
+    </main>
+  );
+}

--- a/next-app/tsconfig.json
+++ b/next-app/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- create a minimal Next.js project under `next-app`
- show a basic interactive counter page and custom 404 page
- document how to run the Next.js app in the README

## Testing
- `python3 -m py_compile self_improvement_app.py`
- `npx tsc -p next-app/tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68400c577d34832bb51437d7a0c8f2a2